### PR TITLE
Remove get

### DIFF
--- a/.swiftpm/xcode/xcuserdata/nate.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/.swiftpm/xcode/xcuserdata/nate.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,14 @@
 		<key>FoundationExtensions.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>0</integer>
+		</dict>
+		<key>Playground (Playground).xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>1</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/FoundationExtensions/KeyPath Extensions.swift
+++ b/FoundationExtensions/KeyPath Extensions.swift
@@ -90,9 +90,3 @@ public func mutate<Root, Value>(
         root = set(keyPath, value)(root)
     }
 }
-
-public func get<Root, Value>(_ kp: KeyPath<Root, Value>) -> (Root) -> Value {
-    { root in
-        root[keyPath: kp]
-    }
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "FoundationExtensions",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v14)
     ],
     products: [
         .library(


### PR DESCRIPTION
we no longer need this `get` function with swift 5.2. So instead of `.map(get(\.foo))`, we can just do `.map(\.foo)