### PR TITLE
Adding unique by test

### DIFF
--- a/FoundationExtensionsTests/SequenceExtensionTests.swift
+++ b/FoundationExtensionsTests/SequenceExtensionTests.swift
@@ -34,7 +34,7 @@ private func == (left: HashableTest, right: HashableTest) -> Bool {
 
 class SequenceExtensionTests: XCTestCase {
 
-    func testUniqueFiltersOutDuplicatesForEquatable() {
+    func test_uniqueFiltersOutDuplicatesForEquatable() {
         let array = [EquatableTest(value: "Value1"), EquatableTest(value: "Value2"), EquatableTest(value: "Value2"), EquatableTest(value: "Value3")]
 
         let uniqueArray = array.unique()
@@ -48,7 +48,7 @@ class SequenceExtensionTests: XCTestCase {
     }
 
 
-    func testUniqueFiltersOutDuplicatesForHashable() {
+    func test_uniqueFiltersOutDuplicatesForHashable() {
         let array = [HashableTest(value: "Value1"), HashableTest(value: "Value2"), HashableTest(value: "Value2"), HashableTest(value: "Value3")]
 
         let uniqueArray = array.unique()
@@ -59,6 +59,20 @@ class SequenceExtensionTests: XCTestCase {
         XCTAssertTrue(uniqueValues.contains("Value1"))
         XCTAssertTrue(uniqueValues.contains("Value2"))
         XCTAssertTrue(uniqueValues.contains("Value3"))
+    }
+    
+    
+    func test_uniqueByFiltersOutDuplicatesKeepingOrdering() {
+        let array = [HashableTest(value: "Value2"), HashableTest(value: "Value3"), HashableTest(value: "Value1"), HashableTest(value: "Value3")]
+
+        let uniqueArray = array.unique(by: \.value)
+
+        XCTAssertEqual(uniqueArray.count, 3)
+
+        let uniqueValues = uniqueArray.map { return $0.value }
+        XCTAssertTrue(uniqueValues[0] == "Value2")
+        XCTAssertTrue(uniqueValues[1] == "Value3")
+        XCTAssertTrue(uniqueValues[2] == "Value1")
     }
 
 

--- a/FoundationExtensionsTests/SequenceExtensionTests.swift
+++ b/FoundationExtensionsTests/SequenceExtensionTests.swift
@@ -41,7 +41,7 @@ class SequenceExtensionTests: XCTestCase {
 
         XCTAssertEqual(uniqueArray.count, 3)
 
-        let uniqueValues = uniqueArray.map { return $0.value }
+        let uniqueValues = uniqueArray.map(\.value)
         XCTAssertTrue(uniqueValues.contains("Value1"))
         XCTAssertTrue(uniqueValues.contains("Value2"))
         XCTAssertTrue(uniqueValues.contains("Value3"))
@@ -69,7 +69,7 @@ class SequenceExtensionTests: XCTestCase {
 
         XCTAssertEqual(uniqueArray.count, 3)
 
-        let uniqueValues = uniqueArray.map { return $0.value }
+        let uniqueValues = uniqueArray.map(\.value)
         XCTAssertTrue(uniqueValues[0] == "Value2")
         XCTAssertTrue(uniqueValues[1] == "Value3")
         XCTAssertTrue(uniqueValues[2] == "Value1")

--- a/FoundationExtensionsTests/SequenceExtensionTests.swift
+++ b/FoundationExtensionsTests/SequenceExtensionTests.swift
@@ -34,7 +34,7 @@ private func == (left: HashableTest, right: HashableTest) -> Bool {
 
 class SequenceExtensionTests: XCTestCase {
 
-    func test_uniqueFiltersOutDuplicatesForEquatable() {
+    func test_unique_filtersOutDuplicatesForEquatable() {
         let array = [EquatableTest(value: "Value1"), EquatableTest(value: "Value2"), EquatableTest(value: "Value2"), EquatableTest(value: "Value3")]
 
         let uniqueArray = array.unique()
@@ -48,7 +48,7 @@ class SequenceExtensionTests: XCTestCase {
     }
 
 
-    func test_uniqueFiltersOutDuplicatesForHashable() {
+    func test_unique_filtersOutDuplicatesForHashable() {
         let array = [HashableTest(value: "Value1"), HashableTest(value: "Value2"), HashableTest(value: "Value2"), HashableTest(value: "Value3")]
 
         let uniqueArray = array.unique()
@@ -62,7 +62,7 @@ class SequenceExtensionTests: XCTestCase {
     }
     
     
-    func test_uniqueByFiltersOutDuplicatesKeepingOrdering() {
+    func test_uniqueBy_filtersOutDuplicatesKeepingOrdering() {
         let array = [HashableTest(value: "Value2"), HashableTest(value: "Value3"), HashableTest(value: "Value1"), HashableTest(value: "Value3")]
 
         let uniqueArray = array.unique(by: \.value)


### PR DESCRIPTION
@natemann I was fixing a bug in 2.0 and ended up using this unique(by:) to preserve ordering of an array being uniqued so I figured I would add a test in this package.